### PR TITLE
Update init.sls

### DIFF
--- a/locale/init.sls
+++ b/locale/init.sls
@@ -2,12 +2,25 @@
 
 {% from "locale/map.jinja" import map with context %}
 
+# /etc/default/keyboard (from keyboard-configuration pkg) and
+# /etc/vconsole.conf must be present otherwise systemd-localed
+# fails (silently!) to start and localectl gives timeout error.
+package_installed_keyboard-configuration:
+  pkg.installed:
+    - name: keyboard-configuration
+
+/etc/vconsole.conf:
+  file.touch
+
 locale_pkgs:
   pkg.installed:
     - pkgs:
       {%- for pkg in map.pkgs %}
         - {{ pkg }}
       {% endfor %}
+    - require:
+      pkg: keyboard-configuration
+      file: /etc/vconsole.conf
 
 {%- set locales = salt['pillar.get']('locale:present', []) %}
 {%- set default = salt['pillar.get']('locale:default', 'en_US.UTF-8') %}


### PR DESCRIPTION
ensure /etc/default/keyboard and /etc/vconsole.conf are present otherwise systemd-localed fails (silently!) to start and localectl gives timeout error